### PR TITLE
upgrade to datafusion 37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,28 +31,28 @@ debug = "line-tables-only"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "50" }
-arrow-arith = { version = "50" }
-arrow-array = { version = "50", features = ["chrono-tz"]}
-arrow-buffer = { version = "50" }
-arrow-cast = { version = "50" }
-arrow-ipc = { version = "50" }
-arrow-json = { version = "50" }
-arrow-ord = { version = "50" }
-arrow-row = { version = "50" }
-arrow-schema = { version = "50" }
-arrow-select = { version = "50" }
+arrow = { version = "51" }
+arrow-arith = { version = "51" }
+arrow-array = { version = "51", features = ["chrono-tz"]}
+arrow-buffer = { version = "51" }
+arrow-cast = { version = "51" }
+arrow-ipc = { version = "51" }
+arrow-json = { version = "51" }
+arrow-ord = { version = "51" }
+arrow-row = { version = "51" }
+arrow-schema = { version = "51" }
+arrow-select = { version = "51" }
 object_store = { version = "0.9" }
-parquet = { version = "50" }
+parquet = { version = "51" }
 
 # datafusion
-datafusion = { version = "36" }
-datafusion-expr = { version = "36" }
-datafusion-common = { version = "36" }
-datafusion-proto = { version = "36" }
-datafusion-sql = { version = "36" }
-datafusion-physical-expr = { version = "36" }
-datafusion-functions = { version = "36" }
+datafusion = { version = "37" }
+datafusion-expr = { version = "37" }
+datafusion-common = { version = "37" }
+datafusion-proto = { version = "37" }
+datafusion-sql = { version = "37" }
+datafusion-physical-expr = { version = "37" }
+datafusion-functions = { version = "37" }
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }

--- a/crates/core/src/data_catalog/storage/mod.rs
+++ b/crates/core/src/data_catalog/storage/mod.rs
@@ -110,12 +110,11 @@ impl SchemaProvider for ListingSchemaProvider {
         self.tables.iter().map(|t| t.key().clone()).collect()
     }
 
-    async fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
-        let location = self.tables.get(name).map(|t| t.clone())?;
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        let location = self.tables.get(name).ok_or(DataFusionError::Execution(format!("Table {} not found", name)))?.clone();
         let provider = open_table_with_storage_options(location, self.storage_options.0.clone())
-            .await
-            .ok()?;
-        Some(Arc::new(provider) as Arc<dyn TableProvider>)
+            .await?;
+        Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>))
     }
 
     fn register_table(

--- a/crates/core/src/data_catalog/storage/mod.rs
+++ b/crates/core/src/data_catalog/storage/mod.rs
@@ -111,9 +111,16 @@ impl SchemaProvider for ListingSchemaProvider {
     }
 
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
-        let location = self.tables.get(name).ok_or(DataFusionError::Execution(format!("Table {} not found", name)))?.clone();
-        let provider = open_table_with_storage_options(location, self.storage_options.0.clone())
-            .await?;
+        let location = self
+            .tables
+            .get(name)
+            .ok_or(DataFusionError::Execution(format!(
+                "Table {} not found",
+                name
+            )))?
+            .clone();
+        let provider =
+            open_table_with_storage_options(location, self.storage_options.0.clone()).await?;
         Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>))
     }
 

--- a/crates/core/src/data_catalog/unity/datafusion.rs
+++ b/crates/core/src/data_catalog/unity/datafusion.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use dashmap::DashMap;
 use datafusion::catalog::schema::SchemaProvider;
 use datafusion::catalog::{CatalogProvider, CatalogProviderList};
-use datafusion_common::DataFusionError;
 use datafusion::datasource::TableProvider;
+use datafusion_common::DataFusionError;
 use tracing::error;
 
 use super::models::{GetTableResponse, ListCatalogsResponse, ListTableSummariesResponse};
@@ -200,7 +200,10 @@ impl SchemaProvider for UnitySchemaProvider {
             GetTableResponse::Error(err) => {
                 // TODO: this previously returned None. Instead we should return a DataFusion Error? (serina)
                 error!("failed to fetch table from unity catalog: {}", err.message);
-                Err(DataFusionError::Execution(format!("failed to fetch table from unity catalog: {}", err.message)))
+                Err(DataFusionError::Execution(format!(
+                    "failed to fetch table from unity catalog: {}",
+                    err.message
+                )))
             }
         }
     }

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -427,9 +427,10 @@ impl<'a> fmt::Display for ScalarValueFormat<'a> {
 #[cfg(test)]
 mod test {
     use arrow_schema::DataType as ArrowDataType;
+    use datafusion::functions_array::expr_fn::cardinality;
     use datafusion::prelude::SessionContext;
     use datafusion_common::{Column, ScalarValue, ToDFSchema};
-    use datafusion_expr::{cardinality, col, lit, substring, Cast, Expr, ExprSchemable};
+    use datafusion_expr::{col, lit, substring, Cast, Expr, ExprSchemable};
     use datafusion_functions::encoding::expr_fn::decode;
 
     use crate::delta_datafusion::{DataFusionMixins, DeltaSessionContext};

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -76,6 +76,18 @@ impl<'a> ContextProvider for DeltaContextProvider<'a> {
     fn get_table_source(&self, _name: TableReference) -> DFResult<Arc<dyn TableSource>> {
         unimplemented!()
     }
+
+    fn udfs_names(&self) -> Vec<String> {
+        self.state.scalar_functions().keys().cloned().collect()
+    }
+
+    fn udafs_names(&self) -> Vec<String> {
+        self.state.aggregate_functions().keys().cloned().collect()
+    }
+
+    fn udwfs_names(&self) -> Vec<String> {
+        self.state.window_functions().keys().cloned().collect()
+    }
 }
 
 /// Parse a string predicate into an `Expr`

--- a/crates/core/src/delta_datafusion/find_files/physical.rs
+++ b/crates/core/src/delta_datafusion/find_files/physical.rs
@@ -9,7 +9,7 @@ use arrow_schema::SchemaRef;
 use datafusion::error::Result;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::memory::MemoryStream;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion::prelude::SessionContext;
 use datafusion_common::tree_node::TreeNode;
 use datafusion_expr::Expr;
@@ -83,6 +83,10 @@ impl ExecutionPlan for FindFilesExec {
 
     fn schema(&self) -> SchemaRef {
         ONLY_FILES_SCHEMA.clone()
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        todo!()
     }
 
     fn output_partitioning(&self) -> Partitioning {

--- a/crates/core/src/delta_datafusion/find_files/physical.rs
+++ b/crates/core/src/delta_datafusion/find_files/physical.rs
@@ -9,7 +9,9 @@ use arrow_schema::SchemaRef;
 use datafusion::error::Result;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::memory::MemoryStream;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, PlanProperties,
+};
 use datafusion::prelude::SessionContext;
 use datafusion_common::tree_node::TreeNode;
 use datafusion_expr::Expr;
@@ -33,12 +35,11 @@ pub struct FindFilesExec {
 
 impl FindFilesExec {
     pub fn new(state: DeltaTableState, log_store: LogStoreRef, predicate: Expr) -> Result<Self> {
-        let cache =
-            PlanProperties::new(
-                EquivalenceProperties::new(ONLY_FILES_SCHEMA.clone()),
-                Partitioning::RoundRobinBatch(num_cpus::get()),
-                ExecutionMode::Bounded
-            );
+        let cache = PlanProperties::new(
+            EquivalenceProperties::new(ONLY_FILES_SCHEMA.clone()),
+            Partitioning::RoundRobinBatch(num_cpus::get()),
+            ExecutionMode::Bounded,
+        );
         Ok(Self {
             predicate,
             log_store,

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -53,9 +53,12 @@ use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::physical_optimizer::pruning::PruningPredicate;
 use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::limit::LocalLimitExec;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning, PlanProperties, SendableRecordBatchStream, Statistics};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
+    PlanProperties, SendableRecordBatchStream, Statistics,
+};
 use datafusion_common::scalar::ScalarValue;
-use datafusion_common::tree_node::{TreeNode, TreeNodeVisitor, TreeNodeRecursion};
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
 use datafusion_common::{
     Column, DFSchema, DataFusionError, Result as DataFusionResult, ToDFSchema,
 };

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -897,7 +897,12 @@ pub(crate) fn get_null_of_arrow_type(t: &ArrowDataType) -> DeltaResult<ScalarVal
             Box::new(get_null_of_arrow_type(v).unwrap()),
         )),
         //Unsupported types...
+        // serina: views are unsupported since datafusion says they're not fully supported
         ArrowDataType::Float16
+        | ArrowDataType::BinaryView
+        | ArrowDataType::Utf8View
+        | ArrowDataType::ListView(_)
+        | ArrowDataType::LargeListView(_)
         | ArrowDataType::Decimal256(_, _)
         | ArrowDataType::Union(_, _)
         | ArrowDataType::LargeList(_)

--- a/crates/core/src/delta_datafusion/physical.rs
+++ b/crates/core/src/delta_datafusion/physical.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use arrow_schema::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::Result as DataFusionResult;
-use datafusion::physical_plan::{DisplayAs, PlanProperties};
 use datafusion::physical_plan::{
     metrics::{ExecutionPlanMetricsSet, MetricsSet},
     ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
 };
+use datafusion::physical_plan::{DisplayAs, PlanProperties};
 use futures::{Stream, StreamExt};
 
 use crate::DeltaTableError;

--- a/crates/core/src/delta_datafusion/physical.rs
+++ b/crates/core/src/delta_datafusion/physical.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use arrow_schema::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::Result as DataFusionResult;
-use datafusion::physical_plan::DisplayAs;
+use datafusion::physical_plan::{DisplayAs, PlanProperties};
 use datafusion::physical_plan::{
     metrics::{ExecutionPlanMetricsSet, MetricsSet},
     ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
@@ -82,12 +82,8 @@ impl ExecutionPlan for MetricObserverExec {
         self.parent.schema()
     }
 
-    fn output_partitioning(&self) -> datafusion::physical_plan::Partitioning {
-        self.parent.output_partitioning()
-    }
-
-    fn output_ordering(&self) -> Option<&[datafusion_physical_expr::PhysicalSortExpr]> {
-        self.parent.output_ordering()
+    fn properties(&self) -> &PlanProperties {
+        self.parent.properties()
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/crates/core/src/kernel/expressions/scalars.rs
+++ b/crates/core/src/kernel/expressions/scalars.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 
 use arrow_array::Array;
+use arrow_schema::DataType::Utf8View;
 use arrow_schema::TimeUnit;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use object_store::path::Path;
@@ -258,6 +259,7 @@ impl Scalar {
                 }
                 Some(Self::Struct(values, struct_fields))
             }
+            // (serina) view types are not yet fully supported in datafusion, so I'm having them convert to None
             Float16
             | Decimal256(_, _)
             | List(_)
@@ -273,6 +275,10 @@ impl Scalar {
             | Dictionary(_, _)
             | RunEndEncoded(_, _)
             | Union(_, _)
+            | BinaryView
+            | Utf8View
+            | ListView(_)
+            | LargeListView(_)
             | Null => None,
         }
     }

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use datafusion::execution::context::SessionState;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion::prelude::SessionContext;
 use datafusion_common::ToDFSchema;
 use futures::future::BoxFuture;

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -18,9 +18,7 @@ use std::{
 
 use arrow_array::{builder::UInt64Builder, ArrayRef, RecordBatch};
 use arrow_schema::SchemaRef;
-use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
-};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream, SendableRecordBatchStream};
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion_physical_expr::{Distribution, PhysicalExpr};
@@ -71,20 +69,16 @@ impl ExecutionPlan for MergeBarrierExec {
         self
     }
 
-    fn schema(&self) -> arrow_schema::SchemaRef {
+    fn schema(&self) -> SchemaRef {
         self.input.schema()
     }
 
-    fn output_partitioning(&self) -> datafusion_physical_expr::Partitioning {
-        self.input.output_partitioning()
+    fn properties(&self) -> &PlanProperties {
+        self.input.properties()
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
         vec![Distribution::HashPartitioned(vec![self.expr.clone()]); 1]
-    }
-
-    fn output_ordering(&self) -> Option<&[datafusion_physical_expr::PhysicalSortExpr]> {
-        None
     }
 
     fn children(&self) -> Vec<std::sync::Arc<dyn ExecutionPlan>> {

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -18,7 +18,10 @@ use std::{
 
 use arrow_array::{builder::UInt64Builder, ArrayRef, RecordBatch};
 use arrow_schema::SchemaRef;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream, SendableRecordBatchStream};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
+    SendableRecordBatchStream,
+};
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion_physical_expr::{Distribution, PhysicalExpr};

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -854,7 +854,8 @@ fn replace_placeholders(expr: Expr, placeholders: &HashMap<String, ScalarValue>)
         }
         _ => Ok(Transformed::no(expr)),
     })
-    .unwrap().data
+    .unwrap()
+    .data
 }
 
 async fn try_construct_early_filter(
@@ -1479,7 +1480,8 @@ fn remove_table_alias(expr: Expr, table_alias: &str) -> Expr {
         },
         _ => Ok(Transformed::no(expr)),
     })
-    .unwrap().data
+    .unwrap()
+    .data
 }
 
 // TODO: Abstract MergePlanner into DeltaPlanner to support other delta operations in the future.

--- a/crates/core/src/operations/transaction/state.rs
+++ b/crates/core/src/operations/transaction/state.rs
@@ -221,24 +221,9 @@ impl<'a> PruningStatistics for AddContainer<'a> {
     }
 
     // This function is required since DataFusion 37.0
-    // I have echoed the null_counts implementation here (Serina)
-    fn row_counts(&self, column: &Column) -> Option<ArrayRef> {
-        let values = self.inner.iter().map(|add| {
-            // the add action has a stats string
-            // number of rows found in statistics.num_records
-            // if stats exists, use num_records. if column exists, num_records. otherwise, 0
-            // if stats doesn't exist, number of rows not known, so null?
-            if let Ok(Some(statistics)) = add.get_stats() {
-                if self.partition_columns.contains(&column.name) {
-                    ScalarValue::UInt64(Some(statistics.num_records as u64))
-                } else {
-                    ScalarValue::UInt64(Some(0))
-                }
-            } else {
-                ScalarValue::UInt64(None)
-            }
-        });
-        ScalarValue::iter_to_array(values).ok()
+    // I made it a no-op and all tests passed
+    fn row_counts(&self, _column: &Column) -> Option<ArrayRef> {
+        None
     }
 }
 

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -36,7 +36,7 @@ use arrow_schema::{ArrowError, DataType, Fields, SchemaRef as ArrowSchemaRef};
 use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
 use datafusion::physical_expr::create_physical_expr;
 use datafusion::physical_plan::filter::FilterExec;
-use datafusion::physical_plan::{memory::MemoryExec, ExecutionPlan};
+use datafusion::physical_plan::{memory::MemoryExec, ExecutionPlan, ExecutionPlanProperties};
 use datafusion_common::DFSchema;
 use datafusion_expr::Expr;
 use futures::future::BoxFuture;

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -44,7 +44,7 @@ use deltalake_core::{
 use std::error::Error;
 
 mod local {
-    use datafusion::common::stats::Precision;
+    use datafusion::{common::stats::Precision, physical_plan::ExecutionPlanProperties};
     use deltalake_core::{logstore::default_logstore, writer::JsonWriter};
     use object_store::local::LocalFileSystem;
 

--- a/crates/sql/src/planner.rs
+++ b/crates/sql/src/planner.rs
@@ -155,6 +155,18 @@ mod tests {
         fn get_window_meta(&self, _name: &str) -> Option<Arc<datafusion_expr::WindowUDF>> {
             None
         }
+
+        fn udfs_names(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn udafs_names(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn udwfs_names(&self) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     fn create_table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {


### PR DESCRIPTION
# Description
Upgrade to DataFusion 37:
- ExecutionPlan has a slightly changed API
- TreeNodeVisitor has a slightly changed API
- Added Utf8View, BinaryView, ListView, and LargeListView as unsupported data types
- SchemaProvider::table returns a Result<Option>> now

This will prepare us to support timestamptz.

# Related Issue(s)

# Documentation